### PR TITLE
Add styles to match with engine_storefront

### DIFF
--- a/app/views/spree/admin/trackers/_form.html.erb
+++ b/app/views/spree/admin/trackers/_form.html.erb
@@ -1,32 +1,48 @@
-<div class="container">
-  <div data-hook="admin_tracker_form_fields" class="row">
-    <div class="col-5">
+<div class="container" data-hook="admin_tracker_form_fields">
+  <div class="row">
+    <div class="col-3">
       <%= f.field_container :analytics_id do %>
-        <%= f.label :analytics_id %>
-        <%= f.text_field :analytics_id, class: 'fullwidth' %>
+        <%= f.label :name %>
+        <%= f.text_field :name, :class => 'fullwidth' %>
       <% end %>
     </div>
 
-     <div class="col-5">
+    <div class="col-3">
+      <%= f.field_container :active do %>
+        <%= f.label :analytics_id %>
+        <%= f.text_field :analytics_id, :class => 'fullwidth' %>
+      <% end %>
+    </div>
+
+    <div class="col-2">
       <%= f.field_container :active do %>
         <%= f.label :active %>
         <ul>
           <li>
-            <%= radio_button(:tracker, :active, true) %>
+            <%= radio_button :tracker, :active, true  %>
             <%= label_tag :tracker_active_true, Spree.t(:say_yes) %>
           </li>
           <li>
-            <%= radio_button(:tracker, :active, false) %>
+            <%= radio_button :tracker, :active, false %>
             <%= label_tag :tracker_active_false, Spree.t(:say_no) %>
           </li>
         </ul>
       <% end %>
     </div>
 
-    <div class="col-5">
-      <%= f.field_container :store_selector do %>
+    <div class="col-2">
+      <%= f.field_container :store do %>
         <%= f.label :store %>
-        <%= collection_select(:tracker, :store_id, Spree::Store.all, :id, :name, {}, class: 'custom-select fullwidth') %>
+        <%= collection_select :tracker, :store_id, Spree::Store.all, :id, :name, {}, :class => 'fullwidth' %>
       <% end %>
     </div>
   </div>
+
+  <div class="row">
+    <div class="col-10">
+      <%= f.field_container :script do %>
+        <%= f.text_area :script, rows: 20, :class => 'fullwidth' %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/spree/admin/trackers/_form.html.erb
+++ b/app/views/spree/admin/trackers/_form.html.erb
@@ -1,13 +1,14 @@
 <div class="container">
   <div data-hook="admin_tracker_form_fields" class="row">
-    <div class="col-md-3">
-      <div data-hook="analytics_id" class="field">
+    <div class="col-5">
+      <%= f.field_container :analytics_id do %>
         <%= f.label :analytics_id %>
-        <%= f.text_field :analytics_id, :class => 'fullwidth' %>
-      </div>
+        <%= f.text_field :analytics_id, class: 'fullwidth' %>
+      <% end %>
     </div>
-    <div class="col-md-3">
-      <div data-hook="active" class="field">
+
+     <div class="col-5">
+      <%= f.field_container :active do %>
         <%= f.label :active %>
         <ul>
           <li>
@@ -19,14 +20,13 @@
             <%= label_tag :tracker_active_false, Spree.t(:say_no) %>
           </li>
         </ul>
-      </div>
+      <% end %>
     </div>
-    <div class="col-md-3">
-      <div data-hook="store_select" class="field">
+
+    <div class="col-5">
+      <%= f.field_container :store_selector do %>
         <%= f.label :store %>
-        <div class="clear"></div>
-        <%= collection_select(:tracker, :store_id, Spree::Store.all, :id, :name, {}) %>
-      </div>
+        <%= collection_select(:tracker, :store_id, Spree::Store.all, :id, :name, {}, class: 'custom-select fullwidth') %>
+      <% end %>
     </div>
   </div>
-</div>

--- a/app/views/spree/admin/trackers/edit.html.erb
+++ b/app/views/spree/admin/trackers/edit.html.erb
@@ -5,7 +5,6 @@
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Tracker), spree.admin_trackers_path) %>
 <% admin_breadcrumb(@tracker.analytics_id) %>
 
-
 <% content_for :page_actions do %>
 <% end %>
 
@@ -14,6 +13,10 @@
 <%= form_for [:admin, @tracker] do |f| %>
   <fieldset class="no-border-top">
     <%= render :partial => 'form', :locals => { :f => f } %>
-    <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+
+    <div class="form-buttons filter-actions actions" data-hook="buttons">
+      <%= button_tag t('spree.actions.update'), :class => 'btn btn-primary' %>
+      <%= link_to t('spree.actions.cancel'), collection_url, :class => 'btn btn-secondary' %>
+    </div>
   </fieldset>
 <% end %>

--- a/app/views/spree/admin/trackers/edit.html.erb
+++ b/app/views/spree/admin/trackers/edit.html.erb
@@ -3,7 +3,7 @@
 <% admin_breadcrumb(Spree.t(:settings)) %>
 <% admin_breadcrumb(Spree.t(:general_settings)) %>
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Tracker), spree.admin_trackers_path) %>
-<% admin_breadcrumb(@tracker.analytics_id) %>
+<% admin_breadcrumb(@tracker.name) %>
 
 <% content_for :page_actions do %>
 <% end %>

--- a/app/views/spree/admin/trackers/index.html.erb
+++ b/app/views/spree/admin/trackers/index.html.erb
@@ -18,14 +18,16 @@
 <% if @trackers.any? %>
   <table class="index">
     <colgroup>
-      <col style="width: 35%">
-      <col style="width: 10%">
       <col style="width: 20%">
+      <col style="width: 20%">
+      <col style="width: 20%">
+      <col style="width: 10%">
       <col style="width: 15%">
     </colgroup>
 
     <thead>
       <tr data-hook="admin_trackers_index_headers">
+        <th><%= Spree::Tracker.human_attribute_name(:name) %></th>
         <th><%= Spree::Tracker.human_attribute_name(:analytics_id) %></th>
         <th><%= Spree::Tracker.human_attribute_name(:active) %></th>
         <th><%= Spree.t(:store) %></th>
@@ -35,9 +37,8 @@
 
     <tbody>
       <% @trackers.each do |tracker|%>
-        <tr id="<%= spree_dom_id tracker %>"
-            data-hook="admin_trackers_index_rows"
-            class="<%= cycle("odd", "even")%>">
+        <tr id="<%= spree_dom_id tracker %>" data-hook="admin_trackers_index_rows" class="<%= cycle("odd", "even")%>">
+          <td><%= tracker.name %></td>
           <td><%= tracker.analytics_id %></td>
           <td><%= tracker.active ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
           <td><%= tracker.store.name %></td>

--- a/app/views/spree/admin/trackers/index.html.erb
+++ b/app/views/spree/admin/trackers/index.html.erb
@@ -7,7 +7,10 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Tracker) %>
     <li>
-      <%= button_link_to Spree.t(:new_tracker), new_object_url, :id => 'admin_new_tracker_link' %>
+      <%= link_to t('spree.new_tracker'),
+                  new_object_url,
+                  :id => 'admin_new_tracker_link',
+                  :class => 'button' %>
     </li>
   <% end %>
 <% end %>
@@ -15,11 +18,12 @@
 <% if @trackers.any? %>
   <table class="index">
     <colgroup>
-      <col style="width: 30%">
-      <col style="width: 40%">
-      <col style="width: 15%">
+      <col style="width: 35%">
+      <col style="width: 10%">
+      <col style="width: 20%">
       <col style="width: 15%">
     </colgroup>
+
     <thead>
       <tr data-hook="admin_trackers_index_headers">
         <th><%= Spree::Tracker.human_attribute_name(:analytics_id) %></th>
@@ -28,11 +32,14 @@
         <th class="actions"></th>
       </tr>
     </thead>
+
     <tbody>
       <% @trackers.each do |tracker|%>
-        <tr id="<%= spree_dom_id tracker %>" data-hook="admin_trackers_index_rows" class="<%= cycle('odd', 'even')%>">
-          <td class="align-center"><%= tracker.analytics_id %></td>
-          <td class="align-center"><%= tracker.active ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
+        <tr id="<%= spree_dom_id tracker %>"
+            data-hook="admin_trackers_index_rows"
+            class="<%= cycle("odd", "even")%>">
+          <td><%= tracker.analytics_id %></td>
+          <td><%= tracker.active ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
           <td><%= tracker.store.name %></td>
           <td class="actions">
             <% if can?(:update, tracker) %>

--- a/db/migrate/20181205183222_add_new_fields_to_spree_trackers.rb
+++ b/db/migrate/20181205183222_add_new_fields_to_spree_trackers.rb
@@ -1,0 +1,6 @@
+class AddNewFieldsToSpreeTrackers < SolidusSupport::Migration[4.2][5.0]
+  def change
+    add_column :spree_trackers, :name, :string
+    add_column :spree_trackers, :script, :text
+  end
+end

--- a/lib/solidus_trackers/factories.rb
+++ b/lib/solidus_trackers/factories.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :tracker, class: Spree::Tracker do
+    name 'Google Analytics'
     analytics_id 'A100'
     active true
+    script '<script></script>'
   end
 end

--- a/spec/features/admin/configuration/analytics_tracker_spec.rb
+++ b/spec/features/admin/configuration/analytics_tracker_spec.rb
@@ -18,13 +18,15 @@ describe "Analytics Tracker", type: :feature do
 
     it "should have the right tabular values displayed" do
       within_row(1) do
-        expect(column_text(1)).to eq("A100")
-        expect(column_text(2)).to eq("Yes")
+        expect(column_text(1)).to eq("Google Analytics")
+        expect(column_text(2)).to eq("A100")
+        expect(column_text(3)).to eq("Yes")
       end
 
       within_row(2) do
-        expect(column_text(1)).to eq("A100")
-        expect(column_text(2)).to eq("Yes")
+        expect(column_text(1)).to eq("Google Analytics")
+        expect(column_text(2)).to eq("A100")
+        expect(column_text(3)).to eq("Yes")
       end
     end
   end
@@ -38,15 +40,18 @@ describe "Analytics Tracker", type: :feature do
 
     it "should be able to create a new analytics tracker" do
       click_link "admin_new_tracker_link"
+      fill_in "tracker_name", with: "Google Analytics"
       fill_in "tracker_analytics_id", with: "A100"
       option = first("#tracker_store_id option").text
       select option, from: "tracker_store_id"
+      fill_in "tracker_script", with: "<script></script>"
       click_button "Create"
 
       expect(page).to have_content("successfully created!")
       within_row(1) do
-        expect(column_text(1)).to eq("A100")
-        expect(column_text(2)).to eq("Yes")
+        expect(column_text(1)).to eq("Google Analytics")
+        expect(column_text(2)).to eq("A100")
+        expect(column_text(3)).to eq("Yes")
       end
     end
   end


### PR DESCRIPTION
Quick Info
---
Migrations? :+1:

What does this change?
----
- Add styles to match with actual style of `engine_storefront`
- Add migration to include `name` and `script` on trackers table
- Update views to add new fields

How do you manually test this?
- Go to `admin` section
- Click on `Settings` menu link
- Click on `Stores`
- Select `Analytics Trackers` tab
----

Screenshots
----
![screencapture-localhost-3000-admin-trackers-2018-12-05-13_33_37](https://user-images.githubusercontent.com/957520/49539119-95fb7b00-f892-11e8-8b56-c1e1c0a0eb95.png)

![screencapture-localhost-3000-admin-trackers-1-edit-2018-12-05-13_34_17](https://user-images.githubusercontent.com/957520/49539134-998f0200-f892-11e8-8518-dab59822054f.png)