### PR TITLE
Feature/solidus trackers multitenant audit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,19 @@
 source 'https://rubygems.org'
 
-git_source(:github) { |repo_name| 'https://github.com/#{repo_name}.git' }
+# git_source(:github) { |repo_name| 'https://github.com/#{repo_name}.git' }
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-gem 'solidus', github: 'solidusio/solidus', branch: branch
+gem 'solidus', github: 'geminimvp/solidus', branch: 'gemini_master_v271'
 gem 'solidus_auth_devise', '~> 1.0'
 
-if branch == 'master' || branch >= 'v2.3'
-  gem 'rails', '>= 5.1.0'
-elsif branch >= 'v2.0'
-  gem 'rails', '~> 5.0.0'
-end
+# if branch == 'master' || branch >= 'v2.3'
+#   gem 'rails', '>= 5.1.0'
+# elsif branch >= 'v2.0'
+#   gem 'rails', '~> 5.0.0'
+# end
+gem 'rails', '5.2.3'
 
-gem 'mysql2', '~> 0.4.10'
+# gem 'mysql2', '~> 0.4.10'
 gem 'pg', '~> 0.21'
 
 group :test do

--- a/app/controllers/spree/admin/trackers_controller.rb
+++ b/app/controllers/spree/admin/trackers_controller.rb
@@ -1,2 +1,36 @@
 class Spree::Admin::TrackersController < Spree::Admin::ResourceController
+    before_action :find_tracker, only: [:edit, :update, :destroy]
+
+    def index
+      @trackers = Spree::Tracker.where(store_id: current_store.id)
+    end
+
+    def show
+      @trackers = Spree::Tracker.where(store_id: current_store.id)
+    end
+
+    def new
+      @tracker = Spree::Tracker.new
+    end
+
+    def create
+      @tracker = Spree::Tracker.new(tracker_params)
+
+      if @tracker.save
+        flash[:success] = "Tracker created"
+        redirect_to admin_trackers_path
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def tracker_params
+      params.require(:tracker).permit(:id, :analytics_id, :active, :store_id, :tracker_type, :name, :script, :options, :app_id)
+    end
+
+    def find_tracker
+      @tracker = Spree::Tracker.where(store_id: current_store.id).find(params[:id])
+    end
 end

--- a/app/models/spree/tracker.rb
+++ b/app/models/spree/tracker.rb
@@ -30,4 +30,8 @@ class Spree::Tracker < ActiveRecord::Base
                          store_id: store,
                          tracker_type: type).first
   end
+
+  def boolean_to_string
+    active ? 'Active' : 'Inactive'
+  end
 end

--- a/lib/solidus_trackers/factories.rb
+++ b/lib/solidus_trackers/factories.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     analytics_id { 'A100' }
     active { true }
     tracker_type { 'google_analytics' }
+    store
   end
 end

--- a/spec/features/admin/configuration/analytics_tracker_spec.rb
+++ b/spec/features/admin/configuration/analytics_tracker_spec.rb
@@ -2,11 +2,13 @@ require 'spec_helper'
 
 describe "Analytics Tracker", type: :feature do
   stub_authorization!
-  let!(:store) { create(:store) }
+  let!(:store1) { create(:store) }
+  let!(:tracker1) { create(:tracker, store: store1) }
+  let!(:store2) { create(:store) }
+  let!(:tracker2) { create(:tracker, analytics_id: 'B100', tracker_type: 'facebook_pixel', active: false, store: store2) }
 
   context "index" do
     before(:each) do
-      2.times { create(:tracker, store: store) }
       visit spree.admin_path
       click_link "Settings"
       click_link "Analytics Tracker"
@@ -16,17 +18,19 @@ describe "Analytics Tracker", type: :feature do
       expect(page).to have_content("Analytics Trackers")
     end
 
-    it "should have the right tabular values displayed" do
+    it "should have the right tabular values displayed for the current store" do
       within_row(1) do
-        expect(column_text(1)).to eq("A100")
-        expect(column_text(2)).to eq("Google Analytics")
-        expect(column_text(3)).to eq("Active")
+        expect(column_text(1)).to eq(tracker1.analytics_id)
+        expect(column_text(2)).to eq(tracker1.tracker_type.split('_').map(&:capitalize).join(' '))
+        expect(column_text(3)).to eq(tracker1.boolean_to_string)
       end
+    end
 
-      within_row(2) do
-        expect(column_text(1)).to eq("A100")
-        expect(column_text(2)).to eq("Google Analytics")
-        expect(column_text(3)).to eq("Active")
+    it "should not have the tabular values displayed for the other store" do
+      within_row(1) do
+        expect(column_text(1)).to_not eq(tracker2.analytics_id)
+        expect(column_text(2)).to_not eq(tracker2.tracker_type.split('_').map(&:capitalize).join(' '))
+        expect(column_text(3)).to_not eq(tracker2.boolean_to_string)
       end
     end
   end
@@ -36,27 +40,33 @@ describe "Analytics Tracker", type: :feature do
       visit spree.admin_path
       click_link "Settings"
       click_link "Analytics Tracker"
+      click_link "admin_new_tracker_link"
+      fill_in "tracker_analytics_id", with: tracker1.analytics_id
+      select all("#tracker_tracker_type option")[1].text, from: "tracker_tracker_type"
+      click_button "Create"
     end
 
-    it "should be able to create a new analytics tracker" do
-      click_link "admin_new_tracker_link"
-      fill_in "tracker_analytics_id", with: "A100"
-      select all("#tracker_tracker_type option")[1].text, from: "tracker_tracker_type"
-      select all("#tracker_store_id option")[1].text, from: "tracker_store_id"
-      click_button "Create"
-
-      expect(page).to have_content("successfully created!")
+    it "should be able to create a new analytics tracker for the current store only" do
+      expect(page).to have_content("Tracker created")
       within_row(1) do
-        expect(column_text(1)).to eq("A100")
-        expect(column_text(2)).to eq("Google Analytics")
-        expect(column_text(3)).to eq("Active")
+        expect(column_text(1)).to eq(tracker1.analytics_id)
+        expect(column_text(2)).to eq(tracker1.tracker_type.split('_').map(&:capitalize).join(' '))
+        expect(column_text(3)).to eq(tracker1.boolean_to_string)
+      end
+    end
+
+    it "should not be able to create a new analytics tracker for the other store only" do
+      within_row(1) do
+        expect(column_text(1)).to_not eq(tracker2.analytics_id)
+        expect(column_text(2)).to_not eq(tracker2.tracker_type.split('_').map(&:capitalize).join(' '))
+        expect(column_text(3)).to_not eq(tracker2.boolean_to_string)
       end
     end
   end
 
   context "store" do
-    it "should display the script tag if a tracking id is provided" do
-      create(:tracker, store: store)
+    it "should display the script tag if a tracking id is provided for the current store only" do
+      create(:tracker, store: store1)
 
       visit spree.root_path
       expect(page).to have_css('#solidus_trackers_google_analytics', visible: false)

--- a/spec/models/spree/tracker_spec.rb
+++ b/spec/models/spree/tracker_spec.rb
@@ -58,4 +58,14 @@ describe Spree::Tracker, type: :model do
       expect(Spree::Tracker.by_type(store, tracker.tracker_type)).to eq(tracker)
     end
   end
+
+  describe 'by current store' do
+    it 'returns only the tracker that belongs to the current store' do
+      expect(tracker.store).to eq(store)
+    end
+
+    it 'does not return the tracker that belongs to the other store' do
+      expect(other_tracker.store).to_not eq(store)
+    end
+  end
 end

--- a/spec/requests/admin/trackers_controller_spec.rb
+++ b/spec/requests/admin/trackers_controller_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Trackers Controller', type: :request do
+  describe 'GET /admin/trackers' do
+    context 'when multiple stores with trackers exist' do
+      stub_authorization!
+
+      let!(:store1) { create(:store) }
+      let!(:tracker1) { create(:tracker, store: store1) }
+      let!(:store2) { create(:store) }
+      let!(:tracker2) { create(:tracker, store: store2) }
+
+      before do
+        get '/admin/trackers'
+      end
+
+      it 'loads trackers for the current store' do
+        expect(assigns(:trackers)).to include(tracker1)
+      end
+
+      it 'does not load trackers for the other store' do
+        expect(assigns(:trackers)).to_not include(tracker2)
+      end
+    end
+  end
+
+  describe 'POST /admin/trackers/new' do
+    context 'when multiple stores exist' do
+      stub_authorization!
+
+      let!(:tracker) {
+        create(:tracker, store: store1)
+      }
+      let!(:store1) { create(:store) }
+      let!(:tracker1) {
+        create(:tracker, store: store1)
+      }
+
+      let!(:store2) { create(:store) }
+
+      let(:create_params) {
+        {
+          tracker: tracker_params,
+        }
+      }
+      let(:tracker_params) {
+        {
+          name: "Tracker",
+          tracker_id: tracker.id,
+          store_id: store1.id,
+        }
+      }
+
+      it 'associates the tracker with the current store' do
+        expect {
+          post "/admin/trackers", params: create_params
+        }.to change {
+          Spree::Tracker.count
+        }.by(1)
+      end
+    end
+  end
+
+  describe 'PUT /admin/trackers' do
+    context 'when the tracker belongs to another store' do
+      stub_authorization!
+
+      let!(:tracker) {
+        create(:tracker)
+      }
+      let!(:store1) { create(:store) }
+      let!(:store2) { create(:store) }
+      let!(:tracker2) {
+        create(:tracker, store: store2)
+      }
+
+      let(:update_params) {
+        {
+          tracker: tracker_params,
+        }
+      }
+
+      let(:tracker_params) {
+        {
+          name: 'Another Tracker',
+          tracker_id: tracker.id,
+          store_id: store1.id,
+        }
+      }
+
+      before do
+        put "/admin/trackers/#{tracker2.id}", params: update_params
+      end
+
+      it 'redirects to the trackers index page' do
+        expect(response.status).to redirect_to('/admin/trackers')
+      end
+
+      it "does not update the other stores' tracker" do
+          expect(tracker2.reload.name).to_not eq('Another Tracker')
+      end
+    end
+  end
+end


### PR DESCRIPTION
To make `Spree::Trackers` multitenant-safe, I ensured that they were scoped to a (current) Store. The desired and current functionality is that only the Trackers for the `current_store` show for any given Store/User.

Please note that this work spans two repos: Engine Storefront and Engine's branch of Solidus Trackers. I have opened a separate PR for the changes made within Engine Storefront--the changes I've made to Engine Storefront can be found here: geminimvp/engine_storefront#1419. Also, due to the changes that I made within the extension, I have pointed Engine Storefront's `solidus_trackers` gem within the `engine_storefront` gemfile to this branch, `feature/solidus-trackers-multitenant-audit`, since it contains the extension changes.

To test these changes:

- The best way to test these changes via the review app is to create two separate Trackers that belong to two separate Stores and then visit the Admin dashboard's "Analytics Trackers" tab ("Settings" -> "Stores" -> "Analytics Trackers") to check that only the correct, `current_store` Trackers appear.

Outstanding questions:

- It was suggested that I remove the "Analytics Trackers" tab from the Admin dashboard navigation (under "Settings" -> "Stores") since on the frontend, the Trackers do not work properly. That being said, I have commented out the code that handles the "New Tracker" button at the top right of the Admin dashboard and pending changes for the navigation bar are included within another PR. Does anyone have any opinions on what I should do in a situation like this--should I cherry-pick the nav changes or wait until the changes have been merged into master and address any spec failures/issues that may arise then?

- Within this repo, you will notice that I commented out a decent amount of code from the gemfile. The gemfile included `mysql2` even though it is not used anywhere. This inclusion led to issues when trying to run any `Bundler`-related commands. This repo is dependent on the `postgresql`, and by commenting out the inclusion of the `mysql2` gem, any database issues related to these gems were resolved.