### PR TITLE
Update gem to use solidus v2.8 fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # git_source(:github) { |repo_name| 'https://github.com/#{repo_name}.git' }
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-gem 'solidus', github: 'geminimvp/solidus', branch: 'gemini_master_v271'
+gem 'solidus', github: 'geminimvp/solidus', branch: 'gemini_master_v284'
 gem 'solidus_auth_devise', '~> 1.0'
 
 # if branch == 'master' || branch >= 'v2.3'
@@ -14,7 +14,7 @@ gem 'solidus_auth_devise', '~> 1.0'
 gem 'rails', '5.2.3'
 
 # gem 'mysql2', '~> 0.4.10'
-gem 'pg', '~> 0.21'
+gem 'pg', '>= 0.21'
 
 group :test do
   if branch == 'master' || branch >= 'v2.0'

--- a/app/views/spree/admin/trackers/index.html.erb
+++ b/app/views/spree/admin/trackers/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spree/admin/shared/general_tabs' %>
 
-<% admin_breadcrumb(Spree.t(:settings)) %>
-<% admin_breadcrumb(Spree.t(:general_settings)) %>
+<% admin_breadcrumb(I18n.t(:settings, scope: :spree)) %>
+<% admin_breadcrumb(I18n.t(:general_settings, scope: :spree)) %>
 <% admin_breadcrumb(plural_resource_name(Spree::Tracker)) %>
 
 <% content_for :page_actions do %>

--- a/spec/support/forgery_protection.rb
+++ b/spec/support/forgery_protection.rb
@@ -1,0 +1,2 @@
+# Disable forgery protection in tests
+ActionController::Base.allow_forgery_protection = false


### PR DESCRIPTION
Update our gem fork to use `gemini_solidus_v284` which matches what's in
`engine_storefront`.